### PR TITLE
feat: client_list

### DIFF
--- a/mnist/Client/cli1/multi_client_1.py
+++ b/mnist/Client/cli1/multi_client_1.py
@@ -357,4 +357,4 @@ for k in range(0,update_iter): # ===================모델 업데이트를 10번
                 c1_send_u.close()
                 break
 
-
+# feat bracn 추가 

--- a/mnist/Client/cli2/multi_client_2.py
+++ b/mnist/Client/cli2/multi_client_2.py
@@ -351,3 +351,4 @@ for k in range(0,update_iter): # ===================모델 업데이트를 10번
                 c2_send_u.close()
                 break
 
+# feat bracn 추가 

--- a/mnist/Server/multi_server.py
+++ b/mnist/Server/multi_server.py
@@ -273,3 +273,4 @@ for k in range(0,32):
                     else: # 시그널이 잘못되었다면
                         print(f"시그널이 잘못되었습니다. 확인하세요.{what_signal}")
                         break
+# feat bracn 추가 


### PR DESCRIPTION
서버는 계속해서 클라이언트의 상태를 체크 해야한다.
여기서 상태는 글로벌 모델 요청, 로컬 모델 학습 중, 로컬 모델 학습 완료, 로컬 모델을 서버로 전송중, 로컬 모델을 서버로 전송 완료.
위의 코드에서는 클라이언트가 학습을 완료하면 서버에게 로컬 모델을 전송하게 되고, 서버는 클라이언트 2개에서 로컬 모델을 전송 받은 후에 글로벌 모델로 만들기 위해 대기한다. 하지만 여기서 문제가 발생한다. 

서버는 클라이언트1의 로컬 모델을 전송 받았고, 클라이언트2의 모델을 전송 받기 전까지 대기한다. 이때 클라이언트1도 대기 상태에 들어 가야한다. 이 부분이 빠져있어서 다시 클라이언트1은 글로벌 모델을 요청하면서 에러가 발생한다. 